### PR TITLE
Fix empty lists and objects by forcing JsonData to assign a type.

### DIFF
--- a/src/LitJson/JsonMapper.cs
+++ b/src/LitJson/JsonMapper.cs
@@ -396,6 +396,12 @@ namespace LitJson
                     elem_type = inst_type.GetElementType ();
                 }
 
+                // make the JsonData object set its type to JsonType.Array
+                // (otherwise empty lists would have JsonType.None)
+
+                if (list.GetType() == typeof (JsonData))
+                    list.Clear();
+
                 while (true) {
                     object item = ReadValue (elem_type, reader);
                     if (item == null && reader.Token == JsonToken.ArrayEnd)
@@ -418,6 +424,12 @@ namespace LitJson
                 ObjectMetadata t_data = object_metadata[value_type];
 
                 instance = Activator.CreateInstance (value_type);
+
+                // make the JsonData object set its type to JsonType.Object
+                // (otherwise empty objects would have JsonType.None)
+
+                if (instance.GetType() == typeof (JsonData))
+                    ((IDictionary)instance).Clear();
 
                 while (true) {
                     reader.Read ();


### PR DESCRIPTION
Hey there,

LitJSON outputs invalid JSON in an edge case. I sometimes read JSON from a file into a JsonData object and write it back without touching it. That breaks empty lists and objects in the output.

When reading an empty list or an empty object, the type of a JsonData object remains at JsonType.None. In contrast, for non-empty lists, for example, the parser would invoke IList.Add() at least once, which would make JsonData set the correct type via EnsureList().

I fixed it - possibly a little naively - by invoking IList.Clear() and IDictionary.Clear() for instantiated lists and objects, respectively, which is a no-op with the side effect of making the JsonData object set its type.

I have demo code to reproduce the issue. (And I had hoped that I could attach files to a pull request...)

Thomas
