### PR TITLE
propertyinfo.GetSetMethod.invoke instead of propertyinfo.SetValue

### DIFF
--- a/src/LitJson/JsonMapper.cs
+++ b/src/LitJson/JsonMapper.cs
@@ -438,11 +438,16 @@ namespace LitJson
                             PropertyInfo p_info =
                                 (PropertyInfo) prop_data.Info;
 
-                            if (p_info.CanWrite)
-                                p_info.SetValue (
-                                    instance,
-                                    ReadValue (prop_data.Type, reader),
-                                    null);
+                            if (p_info.CanWrite){
+                                //p_info.SetValue(
+                                //   instance,
+                                //   ReadValue(prop_data.Type, reader),
+                                //   null);
+                                //use the getSetMethod.invoke instead of SetValue is to suport more platform
+                                // such as mono run in ios,jit is forbidden,so the p_info.setValue cannot be used
+                                p_info.GetSetMethod().Invoke(instance, new object[] { ReadValue(prop_data.Type, reader) });
+                            }
+                               
                             else
                                 ReadValue (prop_data.Type, reader);
                         }


### PR DESCRIPTION
my unity3d project use the litjson as the json lib, when the project run in ios , it throw a jit exception.the propertyinfo.setValue cannot be use
and then use the getSetMethod.invoke instead of SetValue  to suport more platform which  jit is forbidden like ios
I hope to get your reply,thanks!
